### PR TITLE
Make the import hack of orderly2 functions more reliable.

### DIFF
--- a/.covrignore
+++ b/.covrignore
@@ -1,0 +1,1 @@
+R/import-*.R

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+R/import-*.R linguist-generated=true

--- a/R/import-standalone-utils-assert.R
+++ b/R/import-standalone-utils-assert.R
@@ -1,0 +1,250 @@
+# Standalone file: do not edit by hand
+# Source: <https://github.com/reside-ic/reside.utils/blob/main/R/standalone-utils-assert.R>
+# ----------------------------------------------------------------------
+#
+# ---
+# repo: reside/reside.utils
+# file: standalone-utils-assert.R
+# imports: cli
+# ---
+assert_scalar <- function(x, name = deparse(substitute(x)), arg = name,
+                          call = parent.frame())  {
+  if (length(x) != 1) {
+    cli::cli_abort(
+      c("'{name}' must be a scalar",
+        i = "{name} has length {length(x)}"),
+      call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_character <- function(x, name = deparse(substitute(x)),
+                             arg = name, call = parent.frame()) {
+  if (!is.character(x)) {
+    cli::cli_abort("Expected '{name}' to be character", call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_numeric <- function(x, name = deparse(substitute(x)),
+                           arg = name, call = parent.frame()) {
+  if (!is.numeric(x)) {
+    cli::cli_abort("Expected '{name}' to be numeric", call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_integer <- function(x, name = deparse(substitute(x)),
+                           tolerance = NULL, arg = name,
+                           call = parent.frame()) {
+  if (is.numeric(x)) {
+    rx <- round(x)
+    if (is.null(tolerance)) {
+      tolerance <- sqrt(.Machine$double.eps)
+    }
+    if (!isTRUE(all.equal(x, rx, tolerance = tolerance))) {
+      cli::cli_abort(
+        c("Expected '{name}' to be integer",
+          i = paste("{cli::qty(length(x))}The provided",
+                    "{?value was/values were} numeric, but not very close",
+                    "to integer values")),
+        arg = arg, call = call)
+    }
+    x <- as.integer(rx)
+  } else {
+    cli::cli_abort("Expected '{name}' to be integer", call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_logical <- function(x, name = deparse(substitute(x)),
+                          arg = name, call = parent.frame()) {
+  if (!is.logical(x)) {
+    cli::cli_abort("Expected '{name}' to be logical", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_nonmissing <- function(x, name = deparse(substitute(x)),
+                              arg = name, call = parent.frame()) {
+  if (anyNA(x)) {
+    cli::cli_abort("Expected '{name}' to be non-NA", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_scalar_character <- function(x, name = deparse(substitute(x)),
+                                    allow_null = FALSE,
+                                    arg = name, call = parent.frame()) {
+  if (allow_null && is.null(x)) {
+    return(invisible(x))
+  }
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_character(x, name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}
+
+
+assert_scalar_numeric <- function(x, name = deparse(substitute(x)),
+                                  allow_null = FALSE,
+                                  arg = name, call = parent.frame()) {
+  if (allow_null && is.null(x)) {
+    return(invisible(x))
+  }
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_numeric(x, name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}
+
+
+assert_scalar_integer <- function(x, name = deparse(substitute(x)),
+                                  tolerance = NULL, allow_null = FALSE,
+                                  arg = name, call = parent.frame()) {
+  if (allow_null && is.null(x)) {
+    return(invisible(x))
+  }
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_integer(x, name, tolerance = tolerance, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}
+
+
+assert_scalar_logical <- function(x, name = deparse(substitute(x)),
+                                  allow_null = FALSE,
+                                  arg = name, call = parent.frame()) {
+  if (allow_null && is.null(x)) {
+    return(invisible(x))
+  }
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_logical(x, name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}
+
+
+assert_scalar_size <- function(x, allow_zero = TRUE, allow_null = FALSE,
+                               name = deparse(substitute(x)),
+                               arg = name, call = parent.frame()) {
+  if (allow_null && is.null(x)) {
+    return(invisible(x))
+  }
+  assert_scalar_integer(x, name = name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+  min <- if (allow_zero) 0 else 1
+  if (x < min) {
+    cli::cli_abort("'{name}' must be at least {min}", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_length <- function(x, len, name = deparse(substitute(x)), arg = name,
+                          call = parent.frame()) {
+  if (length(x) != len) {
+    cli::cli_abort(
+      "Expected '{name}' to have length {len}, but was length {length(x)}",
+      arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_is <- function(x, what, name = deparse(substitute(x)), arg = name,
+                      call = parent.frame()) {
+  if (!inherits(x, what)) {
+    cli::cli_abort("Expected '{name}' to be a '{what}' object",
+                   arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_list <- function(x, name = deparse(substitute(x)), arg = name,
+                        call = parent.frame()) {
+  if (!is.list(x)) {
+    cli::cli_abort("Expected '{name}' to be a list",
+                   arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_scalar_positive_numeric <- function(x, allow_zero = TRUE,
+                                           name = deparse(substitute(x)),
+                                           arg = name, call = parent.frame()) {
+  assert_scalar_numeric(x, name = name, call = call)
+  if (allow_zero) {
+    if (x < 0) {
+      cli::cli_abort("'{name}' must be at least 0", arg = arg, call = call)
+    }
+  } else {
+    if (x <= 0) {
+      cli::cli_abort("'{name}' must be greater than 0", arg = arg, call = call)
+    }
+  }
+  invisible(x)
+}
+
+
+assert_scalar_positive_integer <- function(x, allow_zero = TRUE,
+                                           name = deparse(substitute(x)),
+                                           tolerance = NULL, arg = name,
+                                           call = parent.frame()) {
+  assert_scalar_integer(x, name, tolerance = tolerance, arg = arg, call = call)
+  min <- if (allow_zero) 0 else 1
+  if (x < min) {
+    cli::cli_abort("'{name}' must be at least {min}", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_raw <- function(x, len = NULL, name = deparse(substitute(x)),
+                       arg = name, call = parent.frame()) {
+  if (!is.raw(x)) {
+    cli::cli_abort("'{name}' must be a raw vector", arg = arg, call = call)
+  }
+  if (!is.null(len)) {
+    assert_length(x, len, name = name, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_named <- function(x, unique = FALSE, name = deparse(substitute(x)),
+                         arg = name, call = parent.frame()) {
+  nms <- names(x)
+  if (is.null(nms)) {
+    cli::cli_abort("'{name}' must be named", call = call, arg = arg)
+  }
+  if (anyNA(nms) || any(nms == "")) {
+    cli::cli_abort("All elements of '{name}' must be named",
+                   call = call, arg = arg)
+  }
+  if (unique && anyDuplicated(names(x))) {
+    dups <- sprintf("'%s'", unique(names(x)[duplicated(names(x))]))
+    cli::cli_abort(
+      c("'{name}' must have unique names",
+        i = "Found {length(dups)} duplicate{?s}: {dups}"),
+      call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+match_value <- function(x, choices, name = deparse(substitute(x)), arg = name,
+                        call = parent.frame()) {
+  assert_scalar_character(x, call = call, name = name, arg = arg)
+  if (!(x %in% choices)) {
+    choices_str <- paste(sprintf("'%s'", choices), collapse = ", ")
+    cli::cli_abort(c("'{name}' must be one of {choices_str}",
+                     i = "Instead we were given '{x}'"), call = call,
+                   arg = arg)
+  }
+  x
+}

--- a/R/util.R
+++ b/R/util.R
@@ -1,10 +1,10 @@
 ## just be lazy and haul things in from orderly2 for now:
-assert_named <- orderly2:::assert_named
-check_fields <- orderly2:::check_fields
-match_value <- orderly2:::match_value
-file_exists <- orderly2:::file_exists
-expand_dirs <- orderly2:::expand_dirs
-hash_file <- orderly2:::hash_file
-vcapply <- orderly2:::vcapply
-data_frame <- orderly2:::data_frame
-squote <- orderly2:::squote
+assert_named <- function(...) orderly2:::assert_named(...)
+check_fields <- function(...) orderly2:::check_fields(...)
+match_value <- function(...) orderly2:::match_value(...)
+file_exists <- function(...) orderly2:::file_exists(...)
+expand_dirs <- function(...) orderly2:::expand_dirs(...)
+hash_file <- function(...) orderly2:::hash_file(...)
+vcapply <- function(...) orderly2:::vcapply(...)
+data_frame <- function(...) orderly2:::data_frame(...)
+squote <- function(...) orderly2:::squote(...)

--- a/R/util.R
+++ b/R/util.R
@@ -1,7 +1,5 @@
 ## just be lazy and haul things in from orderly2 for now:
-assert_named <- function(...) orderly2:::assert_named(...)
 check_fields <- function(...) orderly2:::check_fields(...)
-match_value <- function(...) orderly2:::match_value(...)
 file_exists <- function(...) orderly2:::file_exists(...)
 expand_dirs <- function(...) orderly2:::expand_dirs(...)
 hash_file <- function(...) orderly2:::hash_file(...)

--- a/tests/testthat/test-sharedfile.R
+++ b/tests/testthat/test-sharedfile.R
@@ -17,7 +17,7 @@ test_that("can copy files in from shared directory", {
   code <- c(
     'p <- orderly.sharedfile::sharedfile_path("mtcars.rds")',
     'saveRDS(readRDS(p), "result.rds")')
-  writeLines(code, file.path(path_src, "orderly.R"))
+  writeLines(code, file.path(path_src, "example.R"))
   id <- suppressMessages(
     orderly2::orderly_run("example", root = root, echo = FALSE))
   expect_type(id, "character")
@@ -53,7 +53,7 @@ test_that("match folder location if needed", {
   code <- c(
     'p <- orderly.sharedfile::sharedfile_path("mtcars.rds")',
     'saveRDS(readRDS(p), "result.rds")')
-  writeLines(code, file.path(path_src, "orderly.R"))
+  writeLines(code, file.path(path_src, "example.R"))
   err <- expect_error(
     suppressMessages(
       orderly2::orderly_run("example", root = root, echo = FALSE)),
@@ -64,7 +64,7 @@ test_that("match folder location if needed", {
   code <- c(
     'p <- orderly.sharedfile::sharedfile_path("mtcars.rds", "other")',
     'saveRDS(readRDS(p), "result.rds")')
-  writeLines(code, file.path(path_src, "orderly.R"))
+  writeLines(code, file.path(path_src, "example.R"))
   expect_error(
     suppressMessages(
       orderly2::orderly_run("example", root = root, echo = FALSE)),
@@ -73,7 +73,7 @@ test_that("match folder location if needed", {
   code <- c(
     'p <- orderly.sharedfile::sharedfile_path("mtcars.rds", "shared2")',
     'saveRDS(readRDS(p), "result.rds")')
-  writeLines(code, file.path(path_src, "orderly.R"))
+  writeLines(code, file.path(path_src, "example.R"))
   expect_error(
     suppressMessages(
       orderly2::orderly_run("example", root = root, echo = FALSE)),
@@ -82,7 +82,7 @@ test_that("match folder location if needed", {
   code <- c(
     'p <- orderly.sharedfile::sharedfile_path("mtcars.rds", "shared1")',
     'saveRDS(readRDS(p), "result.rds")')
-  writeLines(code, file.path(path_src, "orderly.R"))
+  writeLines(code, file.path(path_src, "example.R"))
   id <- suppressMessages(
       orderly2::orderly_run("example", root = root, echo = FALSE))
   expect_type(id, "character")
@@ -110,7 +110,7 @@ test_that("can hash a directory if requested", {
   code <- c(
     'p <- orderly.sharedfile::sharedfile_path("x")',
     'writeLines(readLines(file.path(p, "y/z/a")), "result.txt")')
-  writeLines(code, file.path(path_src, "orderly.R"))
+  writeLines(code, file.path(path_src, "example.R"))
   id <- suppressMessages(
     orderly2::orderly_run("example", root = root, echo = FALSE))
   expect_type(id, "character")
@@ -144,7 +144,7 @@ test_that("can use environment variables as paths", {
   code <- c(
     'p <- orderly.sharedfile::sharedfile_path("mtcars.rds")',
     'saveRDS(readRDS(p), "result.rds")')
-  writeLines(code, file.path(path_src, "orderly.R"))
+  writeLines(code, file.path(path_src, "example.R"))
   id <- suppressMessages(
     orderly2::orderly_run("example", root = root, echo = FALSE))
   expect_type(id, "character")
@@ -176,9 +176,9 @@ test_that("can copy files in from shared directory", {
   code <- c(
     'p <- orderly.sharedfile::sharedfile_path("mtcars.rds")',
     'saveRDS(readRDS(p), "result.rds")')
-  writeLines(code, file.path(path_src, "orderly.R"))
+  writeLines(code, file.path(path_src, "example.R"))
 
-  withr::with_dir(path_src, source("orderly.R"))
+  withr::with_dir(path_src, source("example.R"))
   expect_true(file.exists(file.path(path_src, "result.rds")))
   expect_equal(
     hash_file(file.path(path_src, "result.rds"), "sha256"),

--- a/tests/testthat/test-sharedfile.R
+++ b/tests/testthat/test-sharedfile.R
@@ -68,7 +68,7 @@ test_that("match folder location if needed", {
   expect_error(
     suppressMessages(
       orderly2::orderly_run("example", root = root, echo = FALSE)),
-    "from must be one of 'shared1', 'shared2'")
+    "'from' must be one of 'shared1', 'shared2'")
 
   code <- c(
     'p <- orderly.sharedfile::sharedfile_path("mtcars.rds", "shared2")',


### PR DESCRIPTION
This package currently aliases a couple of internal functions from orderly2 under its own namespace.

I ran into an issue where the following happened:
- An old version of orderly2 is installed, where `assert_named` calls `assert_unique_names`.
- `orderly.sharedfile` is built and installed. The definition of `assert_named` is copied into the `orderly.sharedfile` namespaces.
- orderly2 is updated to a new version, where `assert_unique_names` does not exist anymore and `assert_named` is modified accordingly.
- `orderly.sharedfile:::assert_named` is called and still has the old definition of the function. It calls `orderly2::assert_unique_names`, which fails because this function does not exist anywhere in the user's library.

Obviously our use of internal functions is a hack, but I believe this issue would have happened regardless of whether they were internal or not. The issue really is that the functions and their implementation details were inlined into this package's namespace at build time.

We can workaround this problem by making these functions trampolines instead of aliases. They call the target function in the orderly2 namespace, without ever copying their definitions into this package's namespace.

Dynamic linking is hard.