### PR TITLE
Update to use orderly, not orderly2

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -15,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -23,28 +24,39 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.sharedfile
 Title: Package Title Here
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
@@ -16,12 +16,11 @@ Imports:
     cli,
     fs,
     jsonlite,
-    orderly2 (>= 1.99.3)
+    orderly (>= 1.99.85)
 Suggests:
     jsonvalidate,
     testthat (>= 3.0.0),
     withr
 Config/testthat/edition: 3
 Remotes:
-    mrc-ide/orderly2,
-    ropensci/jsonvalidate
+    mrc-ide/orderly

--- a/R/sharedfile.R
+++ b/R/sharedfile.R
@@ -14,7 +14,7 @@
 ##'
 ##' @export
 sharedfile_path <- function(files, from = NULL) {
-  ctx <- orderly2::orderly_plugin_context("orderly.sharedfile", parent.frame())
+  ctx <- orderly::orderly_plugin_context("orderly.sharedfile", parent.frame())
   folders <- names(ctx$config)
   if (is.null(from)) {
     if (length(folders) > 1) {
@@ -35,7 +35,7 @@ sharedfile_path <- function(files, from = NULL) {
         i = "Root for '{from}' is '{from_path}'"))
   }
 
-  hash_algorithm <- orderly2::orderly_config(ctx$root)$core$hash_algorithm
+  hash_algorithm <- orderly::orderly_config(ctx$root)$core$hash_algorithm
   path_expanded <- expand_dirs(files, from_path)
   hash <- withr::with_dir(
     from_path,
@@ -44,6 +44,6 @@ sharedfile_path <- function(files, from = NULL) {
                      path = path_expanded,
                      hash = unname(hash))
 
-  orderly2::orderly_plugin_add_metadata("orderly.sharedfile", "path", info)
+  orderly::orderly_plugin_add_metadata("orderly.sharedfile", "path", info)
   file.path(from_path, files)
 }

--- a/R/util.R
+++ b/R/util.R
@@ -1,8 +1,8 @@
-## just be lazy and haul things in from orderly2 for now:
-check_fields <- function(...) orderly2:::check_fields(...)
-file_exists <- function(...) orderly2:::file_exists(...)
-expand_dirs <- function(...) orderly2:::expand_dirs(...)
-hash_file <- function(...) orderly2:::hash_file(...)
-vcapply <- function(...) orderly2:::vcapply(...)
-data_frame <- function(...) orderly2:::data_frame(...)
-squote <- function(...) orderly2:::squote(...)
+## just be lazy and haul things in from orderly for now:
+check_fields <- function(...) orderly:::check_fields(...)
+file_exists <- function(...) orderly:::file_exists(...)
+expand_dirs <- function(...) orderly:::expand_dirs(...)
+hash_file <- function(...) orderly:::hash_file(...)
+vcapply <- function(...) orderly:::vcapply(...)
+data_frame <- function(...) orderly:::data_frame(...)
+squote <- function(...) orderly:::squote(...)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,6 @@
 .onLoad <- function(...) {
   # nocov start
-  orderly2::orderly_plugin_register(
+  orderly::orderly_plugin_register(
     "orderly.sharedfile",
     config = config,
     serialise = serialise,

--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@
 [![codecov.io](https://codecov.io/github/mrc-ide/orderly.sharedfile/coverage.svg?branch=main)](https://codecov.io/github/mrc-ide/orderly.sharedfile?branch=main)
 <!-- badges: end -->
 
-This package contains a small plugin for using files from some shared location within [`orderly2`](https://mrc-ide.github.io/orderly2). Unlike [`orderly2::orderly_shared_resource`](https://mrc-ide.github.io/orderly2/reference/orderly_shared_resource.html), the assumption here is that the files are somewhere out of the source tree, for example a mounted shared drive that multiple people access.
+This package contains a small plugin for using files from some shared location within [`orderly`](https://mrc-ide.github.io/orderly). Unlike [`orderly::orderly_shared_resource`](https://mrc-ide.github.io/orderly/reference/orderly_shared_resource.html), the assumption here is that the files are somewhere out of the source tree, for example a mounted shared drive that multiple people access.
 
 We expect that the files are to be read into a running task/report are **read only** and are a source of information, not a destination to write things to.
 
 ## Configuration
-
-**This may change as and when we overhaul `orderly2`'s configuration; we would like to entirely remove the yaml, and are open to suggestions.**
 
 Edit your `orderly_config.yml` to add a section like
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- badges: start -->
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
 [![R build status](https://github.com/mrc-ide/orderly.sharedfile/workflows/R-CMD-check/badge.svg)](https://github.com/mrc-ide/orderly.sharedfile/actions)
-[![codecov.io](https://codecov.io/github/mrc-ide/orderly.sharedfile/coverage.svg?branch=main)](https://codecov.io/github/mrc-ide/orderly.sharedfile?branch=main)
+[![Codecov test coverage](https://codecov.io/gh/mrc-ide/orderly.sharedfile/graph/badge.svg)](https://app.codecov.io/gh/mrc-ide/orderly.sharedfile)
 <!-- badges: end -->
 
 This package contains a small plugin for using files from some shared location within [`orderly`](https://mrc-ide.github.io/orderly). Unlike [`orderly::orderly_shared_resource`](https://mrc-ide.github.io/orderly/reference/orderly_shared_resource.html), the assumption here is that the files are somewhere out of the source tree, for example a mounted shared drive that multiple people access.

--- a/tests/testthat/test-sharedfile.R
+++ b/tests/testthat/test-sharedfile.R
@@ -4,7 +4,7 @@ test_that("can copy files in from shared directory", {
   saveRDS(mtcars, file.path(shared, "mtcars.rds"))
   hash <- hash_file(file.path(shared, "mtcars.rds"), "sha256")
 
-  suppressMessages(orderly2::orderly_init(root))
+  suppressMessages(orderly::orderly_init(root))
   cfg <- c("minimum_orderly_version: 1.99.3",
            "plugins:",
            "  orderly.sharedfile:",
@@ -19,10 +19,10 @@ test_that("can copy files in from shared directory", {
     'saveRDS(readRDS(p), "result.rds")')
   writeLines(code, file.path(path_src, "example.R"))
   id <- suppressMessages(
-    orderly2::orderly_run("example", root = root, echo = FALSE))
+    orderly::orderly_run("example", root = root, echo = FALSE))
   expect_type(id, "character")
 
-  meta <- orderly2::orderly_metadata(id, root = root)
+  meta <- orderly::orderly_metadata(id, root = root)
   expect_length(meta$custom$orderly.sharedfile$path, 1)
   expect_equal(meta$custom$orderly.sharedfile$path[[1]],
                list(from = "incoming", path = "mtcars.rds", hash = hash))
@@ -37,7 +37,7 @@ test_that("match folder location if needed", {
   shared2 <- withr::local_tempdir()
   saveRDS(iris, file.path(shared2, "iris.rds"))
 
-  suppressMessages(orderly2::orderly_init(root))
+  suppressMessages(orderly::orderly_init(root))
   cfg <- c("minimum_orderly_version: 1.99.3",
            "plugins:",
            "  orderly.sharedfile:",
@@ -56,7 +56,7 @@ test_that("match folder location if needed", {
   writeLines(code, file.path(path_src, "example.R"))
   err <- expect_error(
     suppressMessages(
-      orderly2::orderly_run("example", root = root, echo = FALSE)),
+      orderly::orderly_run("example", root = root, echo = FALSE)),
     "'from' must be given as you have more than one folder configured")
   expect_equal(err$parent$body,
                c(i = "Possible values are: 'shared1' and 'shared2'"))
@@ -67,7 +67,7 @@ test_that("match folder location if needed", {
   writeLines(code, file.path(path_src, "example.R"))
   expect_error(
     suppressMessages(
-      orderly2::orderly_run("example", root = root, echo = FALSE)),
+      orderly::orderly_run("example", root = root, echo = FALSE)),
     "'from' must be one of 'shared1', 'shared2'")
 
   code <- c(
@@ -76,7 +76,7 @@ test_that("match folder location if needed", {
   writeLines(code, file.path(path_src, "example.R"))
   expect_error(
     suppressMessages(
-      orderly2::orderly_run("example", root = root, echo = FALSE)),
+      orderly::orderly_run("example", root = root, echo = FALSE)),
     "File in 'shared2' does not exist: 'mtcars.rds'")
 
   code <- c(
@@ -84,7 +84,7 @@ test_that("match folder location if needed", {
     'saveRDS(readRDS(p), "result.rds")')
   writeLines(code, file.path(path_src, "example.R"))
   id <- suppressMessages(
-      orderly2::orderly_run("example", root = root, echo = FALSE))
+      orderly::orderly_run("example", root = root, echo = FALSE))
   expect_type(id, "character")
 })
 
@@ -97,7 +97,7 @@ test_that("can hash a directory if requested", {
     writeLines(i, file.path(shared, "x/y/z", i))
   }
 
-  suppressMessages(orderly2::orderly_init(root))
+  suppressMessages(orderly::orderly_init(root))
   cfg <- c("minimum_orderly_version: 1.99.3",
            "plugins:",
            "  orderly.sharedfile:",
@@ -112,10 +112,10 @@ test_that("can hash a directory if requested", {
     'writeLines(readLines(file.path(p, "y/z/a")), "result.txt")')
   writeLines(code, file.path(path_src, "example.R"))
   id <- suppressMessages(
-    orderly2::orderly_run("example", root = root, echo = FALSE))
+    orderly::orderly_run("example", root = root, echo = FALSE))
   expect_type(id, "character")
 
-  meta <- orderly2::orderly_metadata(id, root = root)
+  meta <- orderly::orderly_metadata(id, root = root)
   expect_length(meta$custom$orderly.sharedfile$path, 3)
   expect_setequal(
     vcapply(meta$custom$orderly.sharedfile$path, "[[", "path"),
@@ -129,7 +129,7 @@ test_that("can use environment variables as paths", {
   saveRDS(mtcars, file.path(shared, "mtcars.rds"))
   hash <- hash_file(file.path(shared, "mtcars.rds"), "sha256")
 
-  suppressMessages(orderly2::orderly_init(root))
+  suppressMessages(orderly::orderly_init(root))
   cfg <- c("minimum_orderly_version: 1.99.3",
            "plugins:",
            "  orderly.sharedfile:",
@@ -146,10 +146,10 @@ test_that("can use environment variables as paths", {
     'saveRDS(readRDS(p), "result.rds")')
   writeLines(code, file.path(path_src, "example.R"))
   id <- suppressMessages(
-    orderly2::orderly_run("example", root = root, echo = FALSE))
+    orderly::orderly_run("example", root = root, echo = FALSE))
   expect_type(id, "character")
 
-  meta <- orderly2::orderly_metadata(id, root = root)
+  meta <- orderly::orderly_metadata(id, root = root)
   expect_length(meta$custom$orderly.sharedfile$path, 1)
   expect_equal(meta$custom$orderly.sharedfile$path[[1]],
                list(from = "incoming", path = "mtcars.rds", hash = hash))
@@ -163,7 +163,7 @@ test_that("can copy files in from shared directory", {
   saveRDS(mtcars, file.path(shared, "mtcars.rds"))
   hash <- hash_file(file.path(shared, "mtcars.rds"), "sha256")
 
-  suppressMessages(orderly2::orderly_init(root))
+  suppressMessages(orderly::orderly_init(root))
   cfg <- c("minimum_orderly_version: 1.99.3",
            "plugins:",
            "  orderly.sharedfile:",


### PR DESCRIPTION
Find and replace, no new features.

The coverage action was updated from usethis, as the old one failed on the first build.  The new version does seem more reliable than the last, which is great